### PR TITLE
fix: eviltrout PR gives error when not displaying ads

### DIFF
--- a/assets/javascripts/discourse/components/adsense-block.js.es6
+++ b/assets/javascripts/discourse/components/adsense-block.js.es6
@@ -1,0 +1,41 @@
+import loadScript from 'discourse/lib/load-script';
+
+export default Ember.Component.extend({
+  visible: false,
+  slotId: null,
+  adStyle: null,
+
+  init() {
+    this._super();
+
+    const { siteSettings } = this;
+    const slot = this.get('slot').trim();
+    const position = slot.replace('_mobile', '');
+    this.set('publisherCode', (siteSettings.adsense_publisher_code || '').trim());
+
+
+    this.set('slotTrim', slot);
+
+    const userSee = (!this.currentUser) ||
+                     (this.currentUser.get('trust_level') <= siteSettings.adsense_through_trust_level);
+
+
+    if (userSee && siteSettings[`adsense_show_${position}`]) {
+      this.set('visible', true);
+      this.set('slotId', siteSettings[`adsense_ad_slot_${slot}`]);
+      const { width, height } = this.getProperties('width', 'height');
+      this.set('adStyle', `display:inline-block; width:${width}px; height:${height}px;`.htmlSafe());
+    }
+  },
+
+  didInsertElement() {
+    this._super();
+    if (this.get('visible')) {
+      loadScript(`//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js`).then(() => {
+        const adsbygoogle = window.adsbygoogle || [];
+        adsbygoogle.push({});
+      });
+    }
+  }
+
+});

--- a/assets/javascripts/discourse/templates/components/adsense-block.hbs
+++ b/assets/javascripts/discourse/templates/components/adsense-block.hbs
@@ -1,0 +1,9 @@
+{{#if visible}}
+  <div class="adsense adsense_{{unbound slotTrim}}">
+    <ins class="adsbygoogle"
+      style={{adStyle}}
+      data-ad-client="{{unbound publisherCode}}"
+      data-ad-slot="{{unbound slotId}}">
+    </ins>
+  </div>
+{{/if}}

--- a/assets/javascripts/discourse/templates/connectors/discovery-list-container-top/adsense.hbs
+++ b/assets/javascripts/discourse/templates/connectors/discovery-list-container-top/adsense.hbs
@@ -1,5 +1,5 @@
 {{#if site.mobileView}}
-  {{adsenseBlock "320" "50" "topiclist_top_mobile"}}
+  {{adsense-block width="320" height="50" slot="topiclist_top_mobile"}}
 {{else}}
-  {{adsenseBlock "728" "90" "topiclist_top"}}
+  {{adsense-block width="728" height="90" slot="topiclist_top"}}
 {{/if}}

--- a/assets/javascripts/discourse/templates/connectors/topic-above-post-stream/adsense.hbs
+++ b/assets/javascripts/discourse/templates/connectors/topic-above-post-stream/adsense.hbs
@@ -1,5 +1,5 @@
 {{#if site.mobileView}}
-  {{adsenseBlock "320" "50" "topic_top_mobile"}}
+  {{adsense-block width="320" height="50" slot="topiclist_top_mobile"}}
 {{else}}
-  {{adsenseBlock "728" "90" "topic_top"}}
+  {{adsense-block width="728" height="90" slot="topiclist_top"}}
 {{/if}}

--- a/assets/javascripts/discourse/templates/connectors/topic-above-suggested/adsense.hbs
+++ b/assets/javascripts/discourse/templates/connectors/topic-above-suggested/adsense.hbs
@@ -1,5 +1,5 @@
 {{#if site.mobileView}}
-  {{adsenseBlock "320" "50" "topic_bottom_mobile"}}
+  {{adsense-block width="320" height="50" slot="topiclist_top_mobile"}}
 {{else}}
-  {{adsenseBlock "728" "90" "topic_bottom"}}
+  {{adsense-block width="728" height="90" slot="topiclist_top"}}
 {{/if}}

--- a/assets/javascripts/initializers/adsense.js.es6
+++ b/assets/javascripts/initializers/adsense.js.es6
@@ -46,29 +46,8 @@ export default {
   name: "apply-adsense",
   initialize(container) {
 
-    const currentUser = container.lookup('current-user:main');
     const siteSettings = container.lookup('site-settings:main');
     const publisherCode = (siteSettings.adsense_publisher_code || '').trim();
-
-    Ember.Handlebars.helper('adsenseBlock', (width, height, slotid) => {
-      if ((currentUser) && ( currentUser.get('trust_level') > siteSettings.adsense_through_trust_level )) {
-          return "";
-      }
-
-      const position = slotid.replace('_mobile', '');
-      if (siteSettings['adsense_show_' + position]) {
-        return new Handlebars.SafeString('<script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>' +
-          '<div class="adsense adsense_' + slotid.trim() + '">' +
-          '<ins class="adsbygoogle" style="display:inline-block;width:' +
-          width + 'px;height:'+ height + 'px" data-ad-client="' + publisherCode +
-          '" data-ad-slot="' + siteSettings['adsense_ad_slot_' + slotid.trim()] + '"></ins>' +
-          '</div>' +
-          '<script> (adsbygoogle = window.adsbygoogle || []).push({}); </script>'
-        );
-      }
-
-      return "";
-    });
 
     if (publisherCode.length) {
       withPluginApi('0.1', initializeAdsense, { noApi: oldPluginCode });


### PR DESCRIPTION
Actually @eviltrout PR https://github.com/discoursehosting/discourse-adsense/pull/35 is working fine except in a case it gives errors when no ads should be displayed. So I just [fixed it](https://github.com/vinothkannans/discourse-adsense/blob/11275bb383c3149216b620421a04735de224bb88/assets/javascripts/discourse/components/adsense-block.js.es6#L33). Now it's working fine on both stable 1.6.x and latest 1.7.0 beta 10 versions of Discourse.

> Currently Helpers in Ember 2.x versions are not compatible with Discourse 1.7.x. We cannot use it until it fixed on Discourse core.