### PR TITLE
Use length over size on jQuery objects.

### DIFF
--- a/assets/javascripts/initializers/adsense.js.es6
+++ b/assets/javascripts/initializers/adsense.js.es6
@@ -2,8 +2,8 @@ import { withPluginApi } from 'discourse/lib/plugin-api';
 import PageTracker from 'discourse/lib/page-tracker';
 
 function __push() {
-  const i = $('.adsense').size();
-  const j = $('.adsense .adsbygoogle ins ins').size();
+  const i = $('.adsense').length;
+  const j = $('.adsense .adsbygoogle ins ins').length;
 
   $('ins.adsbygoogle').each(function(){
     if ($(this).html() === '') {


### PR DESCRIPTION
As per the docs: https://api.jquery.com/size/

```
The .size() method is deprecated as of jQuery 1.8. Use the .length property instead.

The .size() method is functionally equivalent to the .length property; however, the .length property is preferred because it does not have the overhead of a function call.
```
